### PR TITLE
Changed to use student id instead of canvas unique id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ canvas_testing/
 extensions/
 extension_test/
 test.py
+venv
+data.csv

--- a/api_caller.py
+++ b/api_caller.py
@@ -1,0 +1,26 @@
+import json
+from urllib.request import Request, urlopen
+from urllib.parse import urlencode
+from urllib.error import HTTPError
+import settings
+
+BASE_URL = settings.API_URL + "/api/v1"
+
+def make_request(url, method="GET", post_fields={}):
+    full_url = f"{BASE_URL}/{url}"
+    request = Request(full_url)
+    request.add_header("Authorization", f"Bearer {settings.API_KEY}")
+    request.method = method
+    if post_fields:
+        request.data = urlencode(post_fields, doseq=True).encode()
+    
+    try:
+        response = urlopen(request)
+        response_data = response.read().decode("utf-8")
+        return json.loads(response_data)
+    except HTTPError as e:
+        error_message = e.read().decode("utf-8")
+        print(f"HTTP Error {e.code}: {e.reason}")
+        print(f"Error details: {error_message}")
+        print(f"URL: {full_url}")
+        raise

--- a/course.py
+++ b/course.py
@@ -1,7 +1,7 @@
 from canvasapi import Canvas
 import pandas as pd
 import threading
-
+from api_caller import make_request
 
 class CourseGetter:
     student_list = []
@@ -32,23 +32,48 @@ class CourseGetter:
 
     def process_dict(self, user_id_dict):
         ''' filter out non-class id's, create list of student's in dict and student's not in class'''
-        students = self.course.get_users(enrollment_type=["student"])
+        # students = self.course.get_users(enrollment_type=["student"])
+        # print(students)
+
         processed_students = []
         extension_dict = {}
 
+
+        try: 
+             response = make_request(f"courses/{self.id}/users")
+            #  print(response)
+        
+        except Exception as e:
+            print(f"Error fetching users: {str(e)}")
+
+        # student_mapping = {student['sis_user_id']: student['id'] for student in response}
+        # print(student_mapping)
+
+
+
+
+
+
         # Filter out student id not in course, add to unprocessed students.
         def _search_name(student):
-            # print(user_id)
-            # print(user_id_dict)
-            if student.id in user_id_dict:
-                processed_students.append(student.id)
-                extension_dict[student.id] = user_id_dict[student.id]
-                self.student_list.append(f"{str(student)}, {user_id_dict[student.id]}")
+           try:
+                sis_user_id = student.get('sis_user_id')
+                if sis_user_id is not None:
+                    sis_user_id_int = int(sis_user_id)  
+                    if sis_user_id_int in user_id_dict:
+                        processed_students.append(sis_user_id_int)  
+                        extension_dict[student['id']] = user_id_dict[sis_user_id_int]
+                        self.student_list.append(f"{str(student['name'])}, {user_id_dict[sis_user_id_int]}")
+           except ValueError:
+                print(f"Invalid value for sis_user_id: {sis_user_id}")
+           except Exception as e:
+                print(f"Error processing student {student}: {e}")
+
 
         # Produce dict of user_id: extension
         # (There's probably a faster way to do this)
         threads = []
-        for student in students:
+        for student in response:
             # print(student)
             t = threading.Thread(target=_search_name, args=(student,))
             t.start()
@@ -62,6 +87,8 @@ class CourseGetter:
             for student in unprocessed_students:
                 print(student)
             input("\nPress enter to continue.")
+        
+      
 
         return extension_dict
 

--- a/main.py
+++ b/main.py
@@ -180,8 +180,11 @@ class TerminalMenu:
         for quiz, new in quiz_dict.items():
             # print(f"Quiz:{quiz}")
             # print(f"New:{new}")
+           
             extenders.append(QuizExtender(quiz, new, course.get_course()))
+
         self.quiz_extenders = extenders
+       
 
         self.run()
 

--- a/main.py
+++ b/main.py
@@ -16,9 +16,12 @@ class TerminalMenu:
     url = ""
     key = ""
 
+
     def __init__(self, url, key):
         self.url = url
         self.key = key
+
+ 
 
     def display_title(self):
         title = "Canvas Quiz Extender"
@@ -131,7 +134,7 @@ class TerminalMenu:
         """Get all the information for the process to run, make the QuizGetters"""  # all of these should probably be split up a bit
         # Prompt the user for a course ID
         # course_id = input("Enter course ID: ")
-        course_id = 143309
+        course_id = 115472
 
         canvas = Canvas(self.url, self.key)
         try:
@@ -148,6 +151,8 @@ class TerminalMenu:
         quiz_dict = course.get_quizzes()
         self.user_id_dict = course.process_dict(reader.get_student_extensions())
         self.student_list = course.get_student_list()
+
+
 
         # def filter_quizzes(quiz_list, quiz_dict):
         #     # for quiz, id in quiz_dict.items():

--- a/quiz_extender.py
+++ b/quiz_extender.py
@@ -45,9 +45,10 @@ class QuizExtender:
         """
         added_time = int(
             math.ceil(
-                self.time_limit * ((float(extend * 100) - 100) / 100) if extend else 0
+                self.time_limit * extend - self.time_limit if extend else 0
             )
         )
+        
         # rounds up to the nearest multiple of 5
         rounded_time = math.ceil(added_time / 5) * 5
         return added_time

--- a/quiz_extender.py
+++ b/quiz_extender.py
@@ -2,7 +2,7 @@ from canvasapi import Canvas
 import math
 from datetime import datetime, timedelta, timezone, time
 import threading
-
+import pytz
 
 class QuizExtender:
     def __str__(self):
@@ -117,15 +117,52 @@ class QuizExtender:
         returns:
             NULL - POST request is sent to canvas to add assignment overrides to quiz param
         """
-        unlock_time = self.quiz.unlock_at_date
-        lock_time = self.quiz.lock_at_date if self.quiz.lock_at else None
-        due_time = self.quiz.due_at_date if self.quiz.due_at else None
+        print("Is this being printed??")
+        print("Quiz object:", vars(self.quiz))
+
+        if self.quiz.all_dates:
+            first_date_info = self.quiz.all_dates[0]  # Get the first dictionary in the list
+            unlock_time = first_date_info.get('unlock_at', None)
+            lock_time = first_date_info.get('lock_at', None)
+            due_time = first_date_info.get('due_at', None)
+            date_format = "%Y-%m-%dT%H:%M:%SZ"
+            print(unlock_time)
+            print(lock_time)
+            print(due_time)
+            # lock_time = datetime.strptime(lock_time, date_format) 
+            # due_time =  datetime.strptime(due_time, date_format) 
+            # unlock_time = datetime.strptime(unlock_time, date_format) 
+
+            unlock_time = datetime.strptime(unlock_time, date_format).replace(tzinfo=pytz.UTC)
+            lock_time = datetime.strptime(lock_time, date_format).replace(tzinfo=pytz.UTC)
+            due_time = datetime.strptime(due_time, date_format).replace(tzinfo=pytz.UTC)
+
+            local_tz = pytz.timezone("America/Vancouver")
+            unlock_time = unlock_time.astimezone(local_tz)
+            lock_time = lock_time.astimezone(local_tz)
+            due_time = due_time.astimezone(local_tz)  
+
+            print(unlock_time)
+            print(lock_time)
+            print(due_time)
+        else:
+            unlock_time = None
+            lock_time = None
+            due_time = None
+
+
+        # unlock_time = self.quiz.unlock_at_date
+        # lock_time = self.quiz.lock_at_date if self.quiz.lock_at else None
+        # due_time = self.quiz.due_at_date if self.quiz.due_at else None
+
         # turn quiz into assignment so you can add assignment overrides to it
         if not self.is_new:  # classic
             quiz_assignment = self.course.get_assignment(self.quiz.assignment_id)
         else:  # new
             quiz_assignment = self.course.get_assignment(self.quiz.id)
         assignment_overrides = quiz_assignment.get_overrides()
+        print("printing assignment overrides")
+        print( quiz_assignment)
         # clear old overrides
         if assignment_overrides:
             for override in assignment_overrides:
@@ -141,6 +178,7 @@ class QuizExtender:
             extended_lock = (
                 (lock_time + timedelta(minutes=added_time)) if lock_time else None
             )
+            print(extended_lock)
             extended_due = (
                 (due_time + timedelta(minutes=added_time)) if due_time else None
             )


### PR DESCRIPTION
Instructors can now input student id instead of the canvas unique id when extending the quiz time for students. 